### PR TITLE
Add unit tests for librarian creation service

### DIFF
--- a/src/main/java/code/with/vanilson/libraryapplication/admin/AdminController.java
+++ b/src/main/java/code/with/vanilson/libraryapplication/admin/AdminController.java
@@ -41,7 +41,7 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    public AdminController(AdminService adminService) {
+    AdminController(AdminService adminService) {
         this.adminService = adminService;
     }
 


### PR DESCRIPTION
- Added test for handling email conflict in librarian creation (`shouldThrowResourceConflictExceptionWhenEmailExists`).
- Added test for handling contact conflict in librarian creation (`shouldThrowResourceConflictExceptionWhenContactExists`).
- Added test for handling employee code conflict in librarian creation (`shouldThrowResourceConflictExceptionWhenEmployeeCodeExists`).
- Added test for catching `DataIntegrityViolationException` and throwing `ResourceConflictException` with proper error message (`shouldCatchDataIntegrityViolationExceptionAndThrowResourceConflictException`).